### PR TITLE
Add admin setup flow

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -27,9 +27,12 @@ class CreateNewUser implements CreatesNewUsers
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? ['accepted', 'required'] : '',
         ])->validate();
 
+        $isFirstAdmin = !User::where('usertype', '1')->exists();
+
         return User::create([
             'name' => $input['name'],
             'email' => $input['email'],
+            'usertype' => $isFirstAdmin ? '1' : '0',
             'password' => Hash::make($input['password']),
         ]);
     }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -34,6 +34,7 @@ class Kernel extends HttpKernel
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
             // \Illuminate\Session\Middleware\AuthenticateSession::class,
+            \App\Http\Middleware\EnsureAdminExists::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
@@ -63,5 +64,6 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'ensure.admin' => \App\Http\Middleware\EnsureAdminExists::class,
     ];
 }

--- a/app/Http/Middleware/EnsureAdminExists.php
+++ b/app/Http/Middleware/EnsureAdminExists.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use App\Models\User;
+
+class EnsureAdminExists
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if (!User::where('usertype', '1')->exists()) {
+            if (!$request->routeIs('register')) {
+                return redirect()->route('register')->with('first_admin', true);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -6,6 +6,12 @@
 
         <x-jet-validation-errors class="mb-4" />
 
+        @if (session('first_admin'))
+            <div class="mb-4 font-medium text-sm text-green-600">
+                {{ __('Create the administrator account to start using the site.') }}
+            </div>
+        @endif
+
         <form method="POST" action="{{ route('register') }}">
             @csrf
 


### PR DESCRIPTION
## Summary
- add middleware to redirect to registration when no admin user exists
- enable middleware in Kernel and register as `ensure.admin`
- assign admin role to the first user
- show notice on the registration page when creating first admin

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68509a5ca390832fae56e18d3407c943