### PR TITLE
Add Daily Menu feature

### DIFF
--- a/app/Http/Controllers/DailyMenuController.php
+++ b/app/Http/Controllers/DailyMenuController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Models\User;
+use App\Models\Dailymenu;
+
+class DailyMenuController extends Controller
+{
+    private function GetIsAdmin()
+    {
+        return Auth::id() && Auth::user()->usertype == "1" ? true : false;
+    }
+
+    public function index()
+    {
+        $data = Dailymenu::all();
+        $user = Auth::id() ? Auth::user() : null;
+        $isAdmin = $this->GetIsAdmin();
+        return view("admin.pages.dailymenu.dailymenu", compact("data", "isAdmin", "user"));
+    }
+
+    public function create()
+    {
+        $user = Auth::id() ? Auth::user() : null;
+        $isAdmin = $this->GetIsAdmin();
+        return view("admin.pages.dailymenu.createdailymenu", compact("user", "isAdmin"));
+    }
+
+    public function store(Request $request)
+    {
+        $isAdmin = $this->GetIsAdmin();
+        if($isAdmin === true){
+            $data = new Dailymenu;
+
+            $image = $request->productimage;
+            $imagename = time().".".$image->getClientOriginalExtension();
+            $imagepath = 'assets/images/dailymenu';
+            $request->productimage->move($imagepath , $imagename);
+            $data->img = $imagepath."/".$imagename;
+
+            $data->name = $request->productname;
+            $data->price = $request->productprice;
+            $data->desc = $request->productdescription;
+
+            $data->save();
+            return redirect()->route('dailymenu.index')->with('msg', 'New Daily menu entry created');
+        }
+        return redirect()->route('dailymenu.index')->with('msg', "Can't create daily menu entry" );
+    }
+
+    public function edit($dailymenu)
+    {
+        $data = Dailymenu::findOrFail($dailymenu);
+        $user = Auth::id() ? Auth::user() : null;
+        $isAdmin = $this->GetIsAdmin();
+        return view("admin.pages.dailymenu.editdailymenu", compact("data", "user", "isAdmin"));
+    }
+
+    public function update($dailymenu, Request $request)
+    {
+        $isAdmin = $this->GetIsAdmin();
+        if($isAdmin === true){
+            $data = Dailymenu::findOrFail($dailymenu);
+
+            $image = $request->productimage;
+            if($image){
+                $imagename = time().".".$image->getClientOriginalExtension();
+                $imagepath = 'assets/images/dailymenu';
+                $request->productimage->move($imagepath , $imagename);
+                $data->img = $imagepath."/".$imagename;
+            }
+            $data->name = $request->productname;
+            $data->price = $request->productprice;
+            $data->desc = $request->productdescription;
+
+            $data->save();
+            return redirect()->route('dailymenu.index')->with('msg', 'Daily menu entry edited');
+        }
+        return redirect()->route('dailymenu.index')->with('msg', "Can't edit daily menu entry" );
+    }
+
+    public function destroy($dailymenu)
+    {
+        $isAdmin = $this->GetIsAdmin();
+        if($isAdmin === true){
+            $data = Dailymenu::findOrFail($dailymenu);
+            $data->delete();
+            return redirect()->back()->with('msg', 'Daily menu entry deleted successfully');
+        }
+        return redirect()->route('dailymenu.index')->with('msg', "Can't delete daily menu entry" );
+    }
+}

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Auth;
 use App\Models\Food;
 use App\Models\Specialdishes;
 use App\Models\Testimonial;
+use App\Models\Dailymenu;
 
 
 class HomeController extends Controller
@@ -19,6 +20,7 @@ class HomeController extends Controller
         ["text" => "inicio", "href" => "#home"],
         ["text" => "sobre", "href" => "#about"],
         ["text" => "menú", "href" => "#menu"],
+        ["text" => "menú del día", "href" => "#dailymenu"],
         ["text" => "opiniones", "href" => "#testimonial"],
         ["text" => "reservar", "href" => "#book"],
         ["text" => "contacto", "href" => "#contact"],
@@ -33,8 +35,9 @@ class HomeController extends Controller
     {
         $navdata = $this->navdata;
         $fooddata = food::all();
+        $dailymenudata = Dailymenu::all();
         $dishesdata = specialdishes::all();
         $testimonialdata = testimonial::all();
-        return view("home.index", compact('navdata', 'fooddata', 'dishesdata', 'testimonialdata'));
+        return view("home.index", compact('navdata', 'fooddata', 'dailymenudata', 'dishesdata', 'testimonialdata'));
     }
 }

--- a/app/Models/Dailymenu.php
+++ b/app/Models/Dailymenu.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Dailymenu extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'img',
+        'price',
+        'desc',
+    ];
+}

--- a/database/migrations/2023_01_23_000001_create_dailymenus_table.php
+++ b/database/migrations/2023_01_23_000001_create_dailymenus_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateDailymenusTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('dailymenus', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 200)->default('');
+            $table->string('img', 250)->default('');
+            $table->decimal('price', 10, 2)->default(0);
+            $table->text('desc');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('dailymenus');
+    }
+}

--- a/resources/views/admin/pages/dailymenu/createdailymenu.blade.php
+++ b/resources/views/admin/pages/dailymenu/createdailymenu.blade.php
@@ -1,0 +1,100 @@
+<x-admin.index :user="$user" :isAdmin="$isAdmin">
+	<div class="content-wrapper">
+		<div class="row">
+			<div class="col-md-6 grid-margin stretch-card">
+				<div class="card">
+					<div class="card-body">
+						<h4 class="card-title">Daily Menu Form</h4>
+						<p class="card-description">Add daily menu info</p>
+						<form action="{{ route('dailymenu.store') }}" method="post" enctype="multipart/form-data">
+							@csrf
+							<div class="form-group">
+								<label for="productname">Name</label>
+								<input
+									type="text"
+									class="form-control"
+									id="productname"
+									name="productname"
+									placeholder="Input product name"
+									required
+								/>
+							</div>
+
+							<div class="form-group">
+								<label for="productprice">Price</label>
+								<input
+									type="number"
+									class="form-control"
+									id="productprice"
+									name="productprice"
+									placeholder="Input product price up to 2 decimal places"
+									pattern="[0-9]+([\.,][0-9]+)?" 
+									step="0.01"
+									repuired
+								/>
+							</div>
+
+							<div class="form-group">
+								<label>Image upload</label>
+								<div class="input-group col-xs-12">
+									<input
+										type="file"
+										class="form-control file-upload-info"
+										placeholder="Upload product image"
+										id="productimage"
+										name="productimage"
+										required
+									/>
+								</div>
+							</div>
+							<div class="form-group">
+								<img id="tempproductimage" src="#" alt="temp-uploded-img" class="h-auto shadow-sm w-1/2" style="display: none" />
+							</div>
+
+							<div class="form-group">
+								<label for="productdescription">Description</label>
+								<textarea
+									class="form-control"
+									id="productdescription"
+									name="productdescription"
+									rows="4"
+									required
+									placeholder="Input product description"
+								></textarea>
+							</div>
+
+							@if ($isAdmin === true)
+							<button type="submit" class="btn btn-primary mr-2">Add</button>
+							@else
+							<button onclick="alert('Only admin can add daily menu')" type="button" class="btn btn-primary mr-2">Add</button>
+							@endif
+							<a href="{{ route("dailymenu.index") }}" class="btn btn-light">Cancel</a>
+						</form>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<script>
+		var imgInput = document.getElementById("productimage");		
+		imgInput.addEventListener('change', (event) => {
+			if (event.target.files[0]) {
+        var reader = new FileReader();
+        
+				var imgTemp = document.getElementById("tempproductimage");	  
+        reader.onload = function (e) {
+        	imgTemp.setAttribute("src", e.target.result);
+        }
+        
+        reader.readAsDataURL(event.target.files[0]);
+
+        if (imgTemp.style.display === "inline") {
+			    imgTemp.style.display = "block";
+			  } else {
+			    imgTemp.style.display = "inline";
+			  }
+	    }
+		});
+		
+	</script>
+</x-admin.index>

--- a/resources/views/admin/pages/dailymenu/dailymenu.blade.php
+++ b/resources/views/admin/pages/dailymenu/dailymenu.blade.php
@@ -1,0 +1,77 @@
+<x-admin.index :user="$user" :isAdmin="$isAdmin">
+	<div class="content-wrapper">
+		<a href="{{ route('dailymenu.create') }}" class="btn btn-primary mx-2">Add Daily Menu</a>
+	</div>
+
+	<div class="content-wrapper">
+		<div class="col-lg-12 grid-margin stretch-card">
+			<div class="card">
+				<div class="card-body">
+					<h4 class="card-title">Daily Menu Data-Table</h4>					
+					<p class="card-description">
+						Daily Menu information table 
+					</p>
+
+					@if(session()->has('msg'))
+					<p class="alert alert-info">{{ session()->get('msg') }}</p>
+					@endif
+					
+					<table class="table table-hover overflow-auto block">
+						<thead>
+							<tr class="bg-slate-800">
+								@foreach(["Image", "Name", "Price", "Description", "Created at", "", ""] as $heading)
+									<th class="font-bold text-white">{{$heading}}</th>
+								@endforeach
+							</tr>
+						</thead>
+						<tbody>
+							@foreach($data as $data)
+							<tr>
+								<td class="w-32">
+									<img src="{{$data->img}}" alt="{{$data->name}}" class="!w-full !h-auto !rounded-none">
+								</td>
+								<td>{{$data->name}}</td>
+								<td>{{$data->price}}</td>								
+								<td class="max-w-[190px] min-w-[190px] !leading-normal !whitespace-normal break-words">{{$data->desc}}</td>
+								<td>{{$data->created_at}}</td>
+								<td>
+									<a
+										href="{{ route('dailymenu.edit', $data->id) }}"
+										class="badge badge-primary cursor-pointer"
+										>Edit</a
+									>
+								</td>
+								<td>
+									@if ($isAdmin === true)
+									<form method="POST" action="{{ route('dailymenu.destroy', $data->id) }}">
+						        @method('DELETE')
+										@csrf
+
+					        	<button 
+					        		type="submit" 
+					        		class="badge badge-danger cursor-pointer" 
+					        		onclick="return confirmDeleteDailyMenu({{ $data->id }} , '{{ $data->name }}');"
+					        		>Delete</button>
+								  </form>
+									@else
+									<button
+										onclick="alert('Only admin can delete food menu')"
+										class="badge badge-danger cursor-pointer"
+										>Delete</button>
+									@endif
+								</td>
+							</tr>
+							@endforeach
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
+	<script>
+  function confirmDeleteDailyMenu(id, name) {
+      if(!confirm("Are You Sure to delete this daily menu, Named: " + name + ", Id: " + id + "." ))
+      event.preventDefault();
+  }
+ </script>
+</x-admin.index>

--- a/resources/views/admin/pages/dailymenu/editdailymenu.blade.php
+++ b/resources/views/admin/pages/dailymenu/editdailymenu.blade.php
@@ -1,0 +1,90 @@
+<x-admin.index :user="$user" :isAdmin="$isAdmin">
+	<div class="content-wrapper">
+		<div class="row">
+			<div class="col-md-6 grid-margin stretch-card">
+				<div class="card">
+					<div class="card-body">
+						<h4 class="card-title">Daily Menu Form</h4>
+						<p class="card-description">Edit daily menu info</p>
+						<form action="{{ route('dailymenu.update', $data->id ) }}" method="post" enctype="multipart/form-data">
+							@method('PUT')
+							@csrf
+							<div class="form-group">
+								<label for="productname">Name</label>
+								<input
+									type="text"
+									class="form-control"
+									id="productname"
+									name="productname"
+									value="{{ $data->name }}"
+									placeholder="Input product name"
+									required
+								/>
+							</div>
+
+							<div class="form-group">
+								<label for="productprice">Price</label>
+								<input
+									type="number"
+									class="form-control"
+									id="productprice"
+									name="productprice"
+									value="{{ $data->price }}"
+									placeholder="Input product price up to 2 decimal places"
+									pattern="[0-9]+([\.,][0-9]+)?" 
+									step="0.01"
+									repuired
+								/>
+							</div>
+
+							<div class="form-group">
+								<label>Image upload</label>
+								<div class="input-group col-xs-12">
+									<input
+										type="file"
+										class="form-control file-upload-info"
+										placeholder="Upload product image"
+										id="productimageupdate"
+										name="productimage"
+										value="{{ $data->img }}"
+									/>
+								</div>
+							</div>
+							<div class="form-group">
+								<img id="tempproductimageedit" src="{{ $data->img }}" alt="{{ $data->name }}" class="h-auto shadow-sm w-1/2" />
+							</div>
+
+							<div class="form-group">
+								<label for="productdescription">Description</label>
+								<textarea
+									class="form-control"
+									id="productdescription"
+									name="productdescription"
+									rows="4"
+									required
+									placeholder="Input product description"
+								>{{ $data->desc }}</textarea>
+							</div>
+
+							@if ($isAdmin === true)
+							<button type="submit" class="btn btn-primary mr-2">Edit</button>
+							@else
+							<button onclick="alert('Only admin can edit daily menu')" type="button" class="btn btn-primary mr-2">Edit</button>
+							@endif
+							<a href="{{ route("dailymenu.index") }}" class="btn btn-light">Cancel</a>
+						</form>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<script>
+		productimageupdate.onchange = evt => {
+		  const [file] = productimageupdate.files
+		  if (file) {
+		    tempproductimageedit.src = URL.createObjectURL(file)
+		  }
+		}
+		
+	</script>
+</x-admin.index>

--- a/resources/views/admin/partials/sidebar.blade.php
+++ b/resources/views/admin/partials/sidebar.blade.php
@@ -43,8 +43,14 @@
     </li>
     <li class="nav-item">
       <a class="nav-link" href="{{ route('foodmenu.index')}}">
-        <span class="menu-title">Food Menu</span>        
+        <span class="menu-title">Food Menu</span>
         <i class="fa-solid fa-bowl-rice menu-icon"></i>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="{{ route('dailymenu.index')}}">
+        <span class="menu-title">Daily Menu</span>
+        <i class="fa-solid fa-calendar-day menu-icon"></i>
       </a>
     </li>
     <li class="nav-item">

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -8,7 +8,9 @@
     @include("home.partials.header", ['navdata' => $navdata])     
     @include("home.partials.banner", ['bannerImg' => 'assets/images/banner-bg.jpg'])
     @include("home.partials.welcome")
-    @include("home.partials.food", ['fooddata' => $fooddata, 'foodBg' => 'assets/images/food-bg.png']) 
+    @include("home.partials.food", ['fooddata' => $fooddata, 'foodBg' => 'assets/images/food-bg.png'])
+
+    @include("home.partials.dailymenu", ['dailymenudata' => $dailymenudata])
 
     @include("home.partials.testimonial", ['testimonialdata' => $testimonialdata, 'quoteImg' => 'assets/images/quote.png'])
     @include("home.partials.deshes", ['dishesdata' => $dishesdata])

--- a/resources/views/home/partials/dailymenu.blade.php
+++ b/resources/views/home/partials/dailymenu.blade.php
@@ -1,0 +1,25 @@
+    <!-- Daily Menu Area Starts -->
+    <section id="dailymenu" class="bg-slate-100 py-20 w-full">
+      <div class="mx-auto max-w-[980px]">
+        <div class="text-center m-4 max-w-sm mx-auto">
+          <h3 class="font-bold font-cursive-merie text-4xl leading-normal capitalize">
+            <span class="text-amber-400 leading-snug">menú</span> del día
+          </h3>
+        </div>
+        <div class="flex flex-wrap justify-center mt-5">
+          @foreach ($dailymenudata as $data)
+          <div class="max-w-[290px] m-4 shadow-md">
+            <img class="w-full h-auto" src="{{ $data['img'] }}" alt="{{ $data['name'] }}-image">
+            <div class="p-7 bg-white">
+              <div class="flex flex-wrap justify-between font-bold font-cursive-merie text-lg">
+                <h5 class='p-1 leading-normal capitalize'>{{ $data['name'] }}</h5>
+                <span class="text-amber-400 p-1 text-right">${{ $data['price'] }}</span>
+              </div>
+              <p class="pt-4 text-[14px] font-sans-lato text-slate-600 leading-relaxed">{{ $data['desc'] }}</p>
+            </div>
+          </div>
+          @endforeach
+        </div>
+      </div>
+    </section>
+    <!-- Daily Menu Area End -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\AdminController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\ReservationController;
 use App\Http\Controllers\FoodMenuController;
+use App\Http\Controllers\DailyMenuController;
 use App\Http\Controllers\SpecialDishController;
 use App\Http\Controllers\TestimonialController;
 
@@ -42,6 +43,11 @@ Route::resource('reservation', ReservationController::class)->only([
 
 /* Food Menu */
 Route::resource('foodmenu', FoodMenuController::class)->only([
+    'index', 'create', 'store', 'edit', 'update', 'destroy'
+]);
+
+/* Daily Menu */
+Route::resource('dailymenu', DailyMenuController::class)->only([
     'index', 'create', 'store', 'edit', 'update', 'destroy'
 ]);
 


### PR DESCRIPTION
## Summary
- add DailyMenu controller and model
- create migration for dailymenus table
- implement CRUD pages for Daily Menu management
- expose Daily Menu section on the home page
- link Daily Menu in sidebar and routes

## Testing
- `npm test` *(fails: Missing script)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509d1dc540832fa9a6d8fcf5656967