### PR TITLE
Enable site name editing

### DIFF
--- a/app/Http/Controllers/SettingController.php
+++ b/app/Http/Controllers/SettingController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Models\User;
+use App\Models\Setting;
+
+class SettingController extends Controller
+{
+    private function GetIsAdmin()
+    {
+        return Auth::id() && Auth::user()->usertype == "1" ? true : false;
+    }
+
+    public function edit()
+    {
+        $user = Auth::id() ? Auth::user() : null;
+        $isAdmin = $this->GetIsAdmin();
+        $siteName = Setting::where('key', 'site_name')->value('value');
+        $siteLogo = Setting::where('key', 'site_logo')->value('value');
+        return view('admin.pages.settings.edit', compact('user', 'isAdmin', 'siteName', 'siteLogo'));
+    }
+
+    public function update(Request $request)
+    {
+        $isAdmin = $this->GetIsAdmin();
+        if ($isAdmin) {
+            Setting::updateOrCreate(
+                ['key' => 'site_name'],
+                ['value' => $request->sitename]
+            );
+
+            if ($request->hasFile('sitelogo')) {
+                $image = $request->file('sitelogo');
+                $imageName = time() . '.' . $image->getClientOriginalExtension();
+                $imagePath = 'assets/images/logo';
+                $image->move($imagePath, $imageName);
+
+                Setting::updateOrCreate(
+                    ['key' => 'site_logo'],
+                    ['value' => $imagePath . '/' . $imageName]
+                );
+            }
+
+            return redirect()->route('settings.edit')->with('msg', 'Site settings updated');
+        }
+        return redirect()->route('settings.edit')->with('msg', "Can't update site settings");
+    }
+}

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Setting extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['key', 'value'];
+}

--- a/database/migrations/2025_06_16_000000_create_settings_table.php
+++ b/database/migrations/2025_06_16_000000_create_settings_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->string('value');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,7 +16,8 @@ class DatabaseSeeder extends Seeder
         $this->call([
             FoodMenuSeeder::class,
             SpecialDishesSeeder::class,
-            TestimonialSeeder::class
+            TestimonialSeeder::class,
+            SettingSeeder::class,
         ]);
     }
 }

--- a/database/seeders/SettingSeeder.php
+++ b/database/seeders/SettingSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Setting;
+use Illuminate\Database\Seeder;
+
+class SettingSeeder extends Seeder
+{
+    public function run()
+    {
+        Setting::updateOrCreate(
+            ['key' => 'site_name'],
+            ['value' => 'Foodfun']
+        );
+
+        Setting::updateOrCreate(
+            ['key' => 'site_logo'],
+            ['value' => 'assets/images/logo/logo.png']
+        );
+    }
+}

--- a/resources/views/admin/pages/settings/edit.blade.php
+++ b/resources/views/admin/pages/settings/edit.blade.php
@@ -1,0 +1,34 @@
+<x-admin.index :user="$user" :isAdmin="$isAdmin">
+    <div class="content-wrapper">
+        <div class="row">
+            <div class="col-md-6 grid-margin stretch-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h4 class="card-title">Site Name</h4>
+                        <p class="card-description">Update the website name</p>
+                        <form action="{{ route('settings.update') }}" method="post" enctype="multipart/form-data">
+                            @method('PUT')
+                            @csrf
+                            <div class="form-group">
+                                <label for="sitename">Name</label>
+                                <input type="text" class="form-control" id="sitename" name="sitename" value="{{ $siteName }}" required />
+                            </div>
+                            <div class="form-group">
+                                <label for="sitelogo">Logo</label>
+                                <input type="file" class="form-control" id="sitelogo" name="sitelogo" accept="image/*" />
+                                @if($siteLogo)
+                                    <img src="/{{ $siteLogo }}" alt="current logo" class="mt-2 w-24" />
+                                @endif
+                            </div>
+                            @if ($isAdmin === true)
+                            <button type="submit" class="btn btn-primary mr-2">Save</button>
+                            @else
+                            <button onclick="alert('Only admin can edit site name')" type="button" class="btn btn-primary mr-2">Save</button>
+                            @endif
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-admin.index>

--- a/resources/views/admin/partials/head.blade.php
+++ b/resources/views/admin/partials/head.blade.php
@@ -1,7 +1,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <!-- Page Title -->
-<title>Foodfun - Admin</title>
+<title>{{ \App\Models\Setting::where('key','site_name')->value('value') }} - Admin</title>
 <!-- Favicon -->
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">

--- a/resources/views/admin/partials/navbar.blade.php
+++ b/resources/views/admin/partials/navbar.blade.php
@@ -4,16 +4,16 @@
 >
   <div class="navbar-brand-wrapper d-flex align-items-center">
     <a href="{{ route('admin.index') }}">
-      <img src="assets/images/logo/logo2.png" alt="logo" class="logo-dark w-32" />
+      <img src="/{{ \App\Models\Setting::where('key','site_logo')->value('value') }}" alt="logo" class="logo-dark w-32" />
     </a>
   </div>
   <div class="navbar-menu-wrapper d-flex align-items-center flex-grow-1">
     <h5 class="mb-0 font-weight-medium d-none d-lg-flex">
-      Welcome to foodfun admin dashboard!
+      Welcome to {{ \App\Models\Setting::where('key','site_name')->value('value') }} admin dashboard!
     </h5>
     <ul class="navbar-nav navbar-nav-right ml-auto">
       <li>
-        <a href="{{ route('index') }}" class="bedge-primary bg-amber-500 font-bold p-2.5 rounded text-white" target="_blank">Browse foodfun site</a>
+        <a href="{{ route('index') }}" class="bedge-primary bg-amber-500 font-bold p-2.5 rounded text-white" target="_blank">Browse {{ \App\Models\Setting::where('key','site_name')->value('value') }} site</a>
       </li>
       <li class="nav-item dropdown d-none d-xl-inline-flex user-dropdown">
         <a

--- a/resources/views/admin/partials/sidebar.blade.php
+++ b/resources/views/admin/partials/sidebar.blade.php
@@ -71,5 +71,11 @@
         <i class="fa-solid fa-star-half-stroke menu-icon"></i>
       </a>
     </li>
+    <li class="nav-item">
+      <a class="nav-link" href="{{ route('settings.edit')}}">
+        <span class="menu-title">Settings</span>
+        <i class="fa-solid fa-gear menu-icon"></i>
+      </a>
+    </li>
   </ul>
 </nav>

--- a/resources/views/home/partials/footer.blade.php
+++ b/resources/views/home/partials/footer.blade.php
@@ -2,7 +2,7 @@
 	<footer id="contact" class="footer-area bg-slate-800 text-white font-sans-lato">
 	  <div class="flex flex-wrap footer-widget justify-between p-3 py-14 max-w-[960px] mx-auto section-padding">
 	    <div class="basis-[300px] grow shrink p-5 pr-9 single-widget single-widget1">
-	      <a href="/"><img class="w-36 h-auto" src="assets/images/logo/logo2.png" alt="" /></a>
+              <a href="/"><img class="w-36 h-auto" src="/{{ \App\Models\Setting::where('key','site_logo')->value('value') }}" alt="" /></a>
 	      <p class="mt-3 leading-normal">
 	        Which morning fourth great won't is to fly bearing
 	        man. Called unto shall seed, deep, herb set seed

--- a/resources/views/home/partials/head.blade.php
+++ b/resources/views/home/partials/head.blade.php
@@ -3,7 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta http-equiv="X-UA-Compatible" content="ie=edge" />
 <!-- Page Title -->
-<title>Foodfun</title>
+<title>{{ \App\Models\Setting::where('key','site_name')->value('value') }}</title>
 <!-- Favicon -->
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">

--- a/resources/views/home/partials/header.blade.php
+++ b/resources/views/home/partials/header.blade.php
@@ -4,7 +4,7 @@
 	  <div class="mx-4 lg:flex lg:items-center">
 	    <div class="flex items-center justify-between">
 	      <div class="lg:shrink-0">
-	        <a href="{{ route('index') }}"><img src="assets/images/logo/logo.png" alt="logo" class="h-auto lg:m-0 lg:p-2 m-auto max-w-[100px] min-w-[90px] px-2 py-2" /></a>
+                <a href="{{ route('index') }}"><img src="/{{ \App\Models\Setting::where('key','site_logo')->value('value') }}" alt="logo" class="h-auto lg:m-0 lg:p-2 m-auto max-w-[100px] min-w-[90px] px-2 py-2" /></a>
 	      </div>
 	      <div class="nav-ham p-4 lg:hidden cursor-pointer transition ease-in-out duration-75 open">
 	      	@foreach ([1, 2, 3] as $data)

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\FoodMenuController;
 use App\Http\Controllers\DailyMenuController;
 use App\Http\Controllers\SpecialDishController;
 use App\Http\Controllers\TestimonialController;
+use App\Http\Controllers\SettingController;
 
 /*
 |--------------------------------------------------------------------------
@@ -60,6 +61,12 @@ Route::resource('specialdishes', SpecialDishController::class)->only([
 Route::resource('testimonial', TestimonialController::class)->only([
     'index', 'create', 'store', 'edit', 'update', 'destroy'
 ]);
+
+/* Settings */
+Route::controller(SettingController::class)->group(function () {
+    Route::get('/admin/settings', 'edit')->name('settings.edit');
+    Route::put('/admin/settings', 'update')->name('settings.update');
+});
 
 /* jetstream auth */
 Route::middleware(['auth:sanctum', config('jetstream.auth_session'), 'verified'])->group(function () {


### PR DESCRIPTION
## Summary
- add `Setting` model and database table
- seed initial setting for site name
- allow admins to change the site name via new menu item
- make page titles and navbar use the dynamic site name
- support editing site logo

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509f929a54832f9eb8feacde713011